### PR TITLE
Render link as HTML A-Href

### DIFF
--- a/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/youtube/YouTubeItem.java
+++ b/studio-server/src/main/java/com/coremedia/labs/plugins/adapters/youtube/YouTubeItem.java
@@ -116,7 +116,7 @@ class YouTubeItem extends YouTubeHubObject implements Item {
                     new DetailsElement<>("text", formatPreviewString(description)),
                     new DetailsElement<>("lastModified", formatPreviewDate(lastModified)),
                     new DetailsElement<>("videoId", videoId),
-                    new DetailsElement<>("link", getVideoUrl())
+                    new DetailsElement<>("link", "<a target='_blank' href='"+getVideoUrl()+"'>"+getVideoUrl()+"+</a>", true)
             ).stream().filter(p -> Objects.nonNull(p.getValue())).collect(Collectors.toUnmodifiableList())));
   }
 


### PR DESCRIPTION
With the new HTML feature we could show the youtube link as a real working a-href. This allows users to quickly open the video in a new tab and do a preview.