### PR TITLE
optimized pnpm usage in github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,17 +36,25 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7.1.5
+
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: 'pnpm'
+          cache-dependency-path: "studio-client/pnpm-lock.yaml"
 
-      - name: Setup PNPM
+      - name: Setup npm.coremedia.io
         run: |
           NPM_AUTH_TOKEN=$(curl -s -H "Accept: application/json" -H "Content-Type:application/json" -X PUT --data '{"name": "${{ secrets.CM_NPM_USER }}", "password": "${{ secrets.CM_NPM_READ_ONLY_PASSWORD }}"}' https://npm.coremedia.io/-/user/org.couchdb.user:${{ secrets.CM_NPM_USER }} | jq -r .token)
           echo "::add-mask::$NPM_AUTH_TOKEN"
-          echo "NPM_CONFIG_//npm.coremedia.io/:_authToken=$NPM_AUTH_TOKEN" >> $GITHUB_ENV
-          npm install -g pnpm@latest
+          pnpm config set //npm.coremedia.io/:_authToken=$NPM_AUTH_TOKEN
+          pnpm config set @coremedia:registry=https://npm.coremedia.io
+          pnpm config set @jangaroo:registry=https://npm.coremedia.io
 
       - name: Setup Git
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -56,9 +64,6 @@ jobs:
 
       - name: Install PNPM Dependencies
         working-directory: studio-client
-        env:
-          NPM_CONFIG_@coremedia:registry: 'https://npm.coremedia.io'
-          NPM_CONFIG_@jangaroo:registry: 'https://npm.coremedia.io'
         run: pnpm install
 
       - name: Set Release Version

--- a/studio-client/package.json
+++ b/studio-client/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=16",
-    "pnpm": ">=6.14.6"
+    "node": "16",
+    "pnpm": "^7.1.5"
   },
   "devDependencies": {
     "@coremedia/set-version": "^1.1.1",


### PR DESCRIPTION
- utilize pnpm/action-setup in conjunction with actions/setup-node to be able to cache
- pin used pnpm version to avoid build problems in case the lockfile format has changed (see pnpm/pnpm#5187)